### PR TITLE
xsp not copied to the gac

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage
 
 Example usage:
 
-    $ heroku create --stack cedar --buildpack http://github.com/brandur/heroku-buildpack-mono.git
+    $ heroku create --stack cedar --buildpack http://github.com/rodrigoi/heroku-buildpack-mono.git
     $ git push heroku master
 
 The buildpack will detect your app as Mono if it has the file `global.asax` in the root or at one directory depth.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,9 @@ Example usage:
 
 The buildpack will detect your app as Mono if it has the file `global.asax` in the root or at one directory depth.
 
-Pre-compiling Binaries
-----------------------
+TODO
+----
 
-Ignore the lines below. For now, building the binaries is a tedious manual process, but a solution will be along shortly.
-
-    $ export AWS_ACCOUNT_ID=xxx AWS_SECRET=yyy S3_BUCKET=zzz
-    $ support/package_mono 2.10.8
-    $ support/package_xsp 2.10.2
-
+1. Add kayak as a lightweight, event based web server.
+2. Add nuget.exe to pull dependencies on commit
+3. Make deploy conditional to unit test success

--- a/bin/compile
+++ b/bin/compile
@@ -36,6 +36,7 @@ if [ ! -d "${CACHE_DIR}/mono" ]; then
   echo "Fetching Mono v${MONO_VERSION} @ ${MONO_PACKAGE}" | indent
   curl ${MONO_PACKAGE} --silent --max-time 600 -o - | tar xzf - -C ${CACHE_DIR}
 fi
+
 cp -r "${CACHE_DIR}/mono" .
 
 echo "-----> Bundling XSP v${XSP_VERSION}"
@@ -44,8 +45,9 @@ if [ ! -d "${CACHE_DIR}/xsp" ]; then
   curl ${XSP_PACKAGE} --silent --max-time 600 -o - | tar xzf - -C ${CACHE_DIR}
 
   echo "Copying libraries to the GAC" | indent
-  cp -r -v ${CACHE_DIR}/xsp/lib/mono/gac/* ${CACHE_DIR}/mono/lib/mono/gac/
+  cp -r -v ${CACHE_DIR}/xsp/lib/mono/gac/* ./mono/lib/mono/gac/
 fi
+
 cp -r "${CACHE_DIR}/xsp" .
 
 # find a solution file

--- a/bin/compile
+++ b/bin/compile
@@ -45,7 +45,7 @@ if [ ! -d "${CACHE_DIR}/xsp" ]; then
   curl ${XSP_PACKAGE} --silent --max-time 600 -o - | tar xzf - -C ${CACHE_DIR}
 
   echo "Copying libraries to the GAC" | indent
-  cp -r -v ${CACHE_DIR}/xsp/lib/mono/gac/* ./mono/lib/mono/gac/
+  cp -r ${CACHE_DIR}/xsp/lib/mono/gac/* ./mono/lib/mono/gac/
 fi
 
 cp -r "${CACHE_DIR}/xsp" .

--- a/bin/compile
+++ b/bin/compile
@@ -44,7 +44,7 @@ if [ ! -d "${CACHE_DIR}/xsp" ]; then
   curl ${XSP_PACKAGE} --silent --max-time 600 -o - | tar xzf - -C ${CACHE_DIR}
 
   echo "Copying libraries to the GAC" | indent
-  cp -r ${CACHE_DIR}/xsp/lib/mono/gac/* ${CACHE_DIR}/mono/lib/mono/gac/
+  cp -r -v ${CACHE_DIR}/xsp/lib/mono/gac/* ${CACHE_DIR}/mono/lib/mono/gac/
 fi
 cp -r "${CACHE_DIR}/xsp" .
 


### PR DESCRIPTION
Hey!

the compile script wasn't copying the xsp binaries to the gac. Well, at least not in the right location. Please, take a look at my new script.

I was thinking on merging here your other repo (heroku-buildpack-mono-build) but I don't know exactly how to run the scripts from the heroku console (using heroku run bash for example).

Thanks for this buildback!
